### PR TITLE
fix it saying you teleported when you might've not

### DIFF
--- a/scripting/shavit-misc.sp
+++ b/scripting/shavit-misc.sp
@@ -1412,8 +1412,6 @@ public Action Command_Tele(int client, int args)
 
 	TeleportToCheckpoint(client, index);
 
-	Shavit_PrintToChat(client, "%T", "MiscCheckpointsTeleported", client, (index + 1), gS_ChatStrings[sMessageVariable], gS_ChatStrings[sMessageText]);
-
 	return Plugin_Handled;
 }
 
@@ -1610,6 +1608,8 @@ void TeleportToCheckpoint(int client, int index)
 	{
 		Shavit_StopTimer(client);
 	}
+	
+	Shavit_PrintToChat(client, "%T", "MiscCheckpointsTeleported", client, (index + 1), gS_ChatStrings[sMessageVariable], gS_ChatStrings[sMessageText]);
 }
 
 public Action Command_Noclip(int client, int args)


### PR DESCRIPTION
example: make a checkpoint then hold +duck and try to teleport to it with !tele or sm_tele

It now does print that you teleported to checkpoint (x) when teleporting from the menu but I can add a function argument to suppress it if you want